### PR TITLE
Use 'fillchars' for specifing char of vertical separator in tabsidebar

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3577,6 +3577,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  diff		'-'		deleted lines of the 'diff' option
 	  eob		'~'		empty lines below the end of a buffer
 	  lastline	'@'		'display' contains lastline/truncate
+	  tabsidebar	' '		vertical separators for tabsidebar
 
 	Any one that is omitted will fall back to the default.
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -4737,7 +4737,10 @@ static struct charstab filltab[] =
     CHARSTAB_ENTRY(&fill_chars.foldsep,	    "foldsep"),
     CHARSTAB_ENTRY(&fill_chars.diff,	    "diff"),
     CHARSTAB_ENTRY(&fill_chars.eob,	    "eob"),
-    CHARSTAB_ENTRY(&fill_chars.lastline,    "lastline")
+    CHARSTAB_ENTRY(&fill_chars.lastline,    "lastline"),
+#if defined(FEAT_TABSIDEBAR)
+    CHARSTAB_ENTRY(&fill_chars.tabsidebar,  "tabsidebar")
+#endif
 };
 static lcs_chars_T lcs_chars;
 static struct charstab lcstab[] =
@@ -4851,6 +4854,9 @@ set_chars_option(win_T *wp, char_u *value, int is_listchars, int apply,
 		fill_chars.diff = '-';
 		fill_chars.eob = '~';
 		fill_chars.lastline = '@';
+#if defined(FEAT_TABSIDEBAR)
+		fill_chars.tabsidebar = ' ';
+#endif
 	    }
 	}
 	p = value;

--- a/src/structs.h
+++ b/src/structs.h
@@ -3785,6 +3785,9 @@ typedef struct
     int	diff;
     int	eob;
     int	lastline;
+#if defined(FEAT_TABSIDEBAR)
+    int	tabsidebar;
+#endif
 } fill_chars_T;
 
 /*

--- a/src/tabsidebar.c
+++ b/src/tabsidebar.c
@@ -40,16 +40,15 @@ draw_tabsidebar(void)
     int		row = 0;
     int		off = 0;
 #endif
-    char_u	*p = NULL;
+    int	        vs_char = 0;
     int		vertsplit = 0;
     int		vsrow = 0;
 
     if (0 == maxwidth)
 	return;
 
-    p = get_var_value((char_u *)"g:tabsidebar_vertsplit");
-    if (p != NULL)
-	vertsplit = STRCMP(p, "1") == 0;
+    vs_char = curwin->w_fill_chars.tabsidebar;
+    vertsplit = vs_char != ' ';
 
 #ifndef MSWIN
     // We need this section only for the Vim running on WSL.
@@ -82,8 +81,7 @@ draw_tabsidebar(void)
     // draw vert separater
     if (vertsplit && (1 < maxwidth))
     {
-	int	vs_attr;
-	int	vs_char = fillchar_vsep(&vs_attr, curwin);
+	int	vs_attr = HL_ATTR(HLF_C);
 	for (vsrow = 1; vsrow < cmdline_row + 1; vsrow++)
 	    screen_fill(vsrow - 1, vsrow,
 		    (p_tsba ? COLUMNS_WITHOUT_TSB() + 0 : maxwidth - 1),


### PR DESCRIPTION
To avoid using global variable for setting.
And we can change separator character.
How do you think?